### PR TITLE
Use ResourceContexts.jl for resource handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 AbstractTrees = "0.3"
 ReplMaker = "0.2"
 TOML = "1"
+ResourceContexts = "0.1"
 julia = "1.5"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.2.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
-Contexts = "8d208092-d35c-4dd3-a0d7-8325f9cce6b4"
+ResourceContexts = "8d208092-d35c-4dd3-a0d7-8325f9cce6b4"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+Contexts = "8d208092-d35c-4dd3-a0d7-8325f9cce6b4"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/docs/dev.jl
+++ b/docs/dev.jl
@@ -1,0 +1,2 @@
+using LiveServer
+servedocs(doc_env=true, foldername=@__DIR__)

--- a/src/BlobTree.jl
+++ b/src/BlobTree.jl
@@ -134,6 +134,8 @@ end
 
 Blob(root) = Blob(root, RelPath())
 
+_root_resource(b::Blob) = b.root
+
 Base.basename(file::Blob) = basename(file.path)
 Base.abspath(file::Blob) = AbsPath(file.root, file.path)
 Base.isdir(file::Blob) = false
@@ -174,10 +176,11 @@ function Base.open(f::Function, ::Type{T}, file::Blob; kws...) where {T}
     open(f, T, file.root, file.path; kws...)
 end
 
-# Deprecated unscoped form of open
+# Unscoped form of open for Blob
 function Base.open(::Type{T}, file::Blob; kws...) where {T}
-    Base.depwarn("`open(T,::Blob)` is deprecated. Use `@! open(T, ::Blob)` instead.")
-    open(identity, T, file; kws...)
+    call_with_finalized_context() do ctx
+        open(ctx, T, file; kws...)
+    end
 end
 
 # Contexts.jl - based versions of the above.
@@ -267,6 +270,8 @@ struct BlobTree{Root} <: AbstractBlobTree
 end
 
 BlobTree(root) = BlobTree(root, RelPath())
+
+_root_resource(b::BlobTree) = b.root
 
 function AbstractTrees.printnode(io::IO, tree::BlobTree)
     print(io, "📂 ",  basename(tree))

--- a/src/filesystem.jl
+++ b/src/filesystem.jl
@@ -29,13 +29,17 @@ Base.read(root::AbstractFileSystemRoot, path::RelPath) where {T} =
 
 Base.summary(io::IO, root::AbstractFileSystemRoot) = print(io, sys_abspath(root))
 
-function Base.open(f::Function, ::Type{IO}, root::AbstractFileSystemRoot, path;
-                   write=false, read=!write, kws...)
+function Base.open(f::Function, as_type::Type{IO}, root::AbstractFileSystemRoot, path;
+                   kws...)
+    @context f(@! open(as_type, root, path; kws...))
+end
+
+@! function Base.open(::Type{IO}, root::AbstractFileSystemRoot, path;
+                      write=false, read=!write, kws...)
     if !iswriteable(root) && write
         error("Error writing file at read-only path $path")
     end
-    check_scoped_open(f, IO)
-    open(f, sys_abspath(root, path); read=read, write=write, kws...)
+    @! open(sys_abspath(root, path); read=read, write=write, kws...)
 end
 
 function Base.mkdir(root::AbstractFileSystemRoot, path::RelPath; kws...)

--- a/src/filesystem.jl
+++ b/src/filesystem.jl
@@ -57,7 +57,7 @@ end
 Base.readdir(root::AbstractFileSystemRoot, path::RelPath) = readdir(sys_abspath(root, path))
 
 #--------------------------------------------------
-mutable struct FileSystemRoot <: AbstractFileSystemRoot
+struct FileSystemRoot <: AbstractFileSystemRoot
     path::String
     read::Bool
     write::Bool

--- a/src/filesystem.jl
+++ b/src/filesystem.jl
@@ -57,7 +57,7 @@ end
 Base.readdir(root::AbstractFileSystemRoot, path::RelPath) = readdir(sys_abspath(root, path))
 
 #--------------------------------------------------
-struct FileSystemRoot <: AbstractFileSystemRoot
+mutable struct FileSystemRoot <: AbstractFileSystemRoot
     path::String
     read::Bool
     write::Bool


### PR DESCRIPTION
This would use the context passing mechanism in https://github.com/c42f/ResourceContexts.jl to manage resources.

This allows datasets to be opened in the REPL without risking their underlying resource being freed, thereby fixing #8. The existing `open()`-based API is retained but made safe by attaching finalizers to the returned types (as a result, `Blob` and `BlobTree` had to become mutable which was unfortunate).

In addition, the API from ResourceContexts.jl can be used, though this is kept as an implementation detail for now. This is how it looks to open a resource in the REPL using ResourceContexts.jl:

```julia
julia> @! open(dataset("TrueFX"))
📂 Tree  @ /home/chris/.julia/datasets/TrueFX
 📄 AUDUSD-2016-01.zip
 📄 AUDUSD-2016-02.zip
 📄 AUDUSD-2016-03.zip
 📄 CADJPY-2020-01.zip
```

### TODO
* [x] Register Contexts.jl
* [x] Cleanup WIP code
* [x] Tests
* [x] Docs