### PR TITLE
Storage driver for data embedded in Data.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,10 @@ version = "0.2.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
-ResourceContexts = "8d208092-d35c-4dd3-a0d7-8325f9cce6b4"
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
+ResourceContexts = "8d208092-d35c-4dd3-a0d7-8325f9cce6b4"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
@@ -15,8 +16,8 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 AbstractTrees = "0.3"
 ReplMaker = "0.2"
-TOML = "1"
 ResourceContexts = "0.1"
+TOML = "1"
 julia = "1.5"
 
 [extras]

--- a/src/BlobTree.jl
+++ b/src/BlobTree.jl
@@ -300,6 +300,8 @@ Base.abspath(tree::BlobTree) = AbsPath(tree.root, tree.path)
 function Base.getindex(tree::BlobTree, path::RelPath)
     relpath = joinpath(tree.path, path)
     root = tree.root
+    # TODO: Make this more efficient by moving this work to the storage backend?
+    # Sort of like an equivalent of `stat`?
     if isdir(root, relpath)
         BlobTree(root, relpath)
     elseif isfile(root, relpath)
@@ -316,9 +318,9 @@ function Base.getindex(tree::BlobTree, name::AbstractString)
 end
 
 # We've got a weird mishmash of path vs tree handling here.
-# TODO: Can we refactor this to cleanly separate the filesystem commands (which
-# take abstract paths?) from BlobTree and Blob which act as an abstraction over
-# the filesystem or other storage mechanisms?
+# TODO: Can we refactor this to cleanly separate the filesystem-like commands
+# (which take abstract paths?) from BlobTree and Blob which act as an
+# abstraction over the filesystem or other storage mechanisms?
 function Base.joinpath(tree::BlobTree, r::RelPath)
     AbsPath(tree.root, joinpath(tree.path, r))
 end
@@ -332,6 +334,10 @@ function Base.haskey(tree::BlobTree, name::AbstractString)
 end
 
 function Base.readdir(tree::BlobTree)
+    readdir(tree.root, tree.path)
+end
+
+function Base.keys(tree::BlobTree)
     readdir(tree.root, tree.path)
 end
 

--- a/src/DataSets.jl
+++ b/src/DataSets.jl
@@ -461,7 +461,7 @@ Additional projects may be added or removed from the stack with `pushfirst!`,
 """
 PROJECT = StackedDataProject()
 
-# deprecated.
+# deprecated. TODO: Remove dependency on this from JuliaHub
 _current_project = DataProject()
 
 function __init__()
@@ -562,6 +562,7 @@ include("BlobTree.jl")
 
 # Builtin backends
 include("filesystem.jl")
+include("DataTomlStorage.jl")
 
 # Backends
 # include("ZipTree.jl")

--- a/src/DataTomlStorage.jl
+++ b/src/DataTomlStorage.jl
@@ -4,7 +4,7 @@ using Base64
 Storage driver which keeps the data embedded within the TOML file itself.
 Useful for small amounts of self-contained data.
 
-## Metadata spec:
+## Metadata spec
 
 For Blob:
 ```
@@ -107,20 +107,19 @@ end
 # Connect storage backend
 function connect_toml_data_storage(f, config, dataset)
     type = config["type"]
-    if type ∉ ("Blob", "BlobTree")
-        throw(ArgumentError("DataSet type $type not supported for data embedded in Data.toml"))
-    end
     data = get(config, "data", nothing)
     if type == "Blob"
         if !(data isa AbstractString)
             error("TOML data storage requires string data in the \"storage.data\" key")
         end
         f(Blob(TomlDataStorage(dataset, data)))
-    else
+    elseif type == "BlobTree"
         if !(data isa AbstractDict)
             error("TOML data storage requires a dictionary in the \"storage.data\" key")
         end
         f(BlobTree(TomlDataStorage(dataset, data)))
+    else
+        throw(ArgumentError("DataSet type $type not supported for data embedded in Data.toml"))
     end
 end
 

--- a/src/DataTomlStorage.jl
+++ b/src/DataTomlStorage.jl
@@ -1,0 +1,128 @@
+using Base64
+
+"""
+Storage driver which keeps the data embedded within the TOML file itself.
+Useful for small amounts of self-contained data.
+
+## Metadata spec:
+
+For Blob:
+```
+    [datasets.storage]
+    driver="TomlDataStorage"
+    type="Blob"
+    data=\$(base64encode(data))
+```
+
+For BlobTree:
+```
+    [datasets.storage]
+    driver="TomlDataStorage"
+    type="BlobTree"
+
+        [datasets.storage.data.\$(dirname1)]
+        "\$(filename1)" = \$(base64encode(data1))
+        "\$(filename2)" = \$(base64encode(data2))
+
+        [datasets.storage.data.\$(dirname2)]
+        ...
+```
+"""
+struct TomlDataStorage
+    dataset::DataSet
+    data::Union{String,Dict{String,Any}}
+end
+
+# Get TOML data at `path`, returning nothing if not present
+function _getpath(storage::TomlDataStorage, path::RelPath)
+    x = storage.data
+    for c in path.components
+        x = get(x, c, nothing)
+        !isnothing(x) || return nothing
+    end
+    x
+end
+
+#--------------------------------------------------
+# Storage data interface for trees
+
+Base.isdir(storage::TomlDataStorage, path::RelPath) = _getpath(storage, path) isa Dict
+Base.isfile(storage::TomlDataStorage, path::RelPath) = _getpath(storage, path) isa String
+Base.ispath(storage::TomlDataStorage, path::RelPath) = !isnothing(_getpath(storage, path))
+
+Base.summary(io::IO, storage::TomlDataStorage) = print(io, "Data.toml")
+
+function Base.readdir(storage::TomlDataStorage, path::RelPath)
+    try
+        tree = _getpath(storage, path)
+        !isnothing(tree) || KeyError(path)
+        sort!(collect(keys(tree::AbstractDict)))
+    catch
+        error("TOML storage requires trees to be as TOML dictionaries")
+    end
+end
+
+#--------------------------------------------------
+# Storage data interface for Blob
+
+function Base.open(func::Function, as_type::Type{IO},
+                   storage::TomlDataStorage, path; kws...)
+    @context func(@! open(as_type, storage, path; kws...))
+end
+
+@! function Base.open(::Type{Vector{UInt8}}, storage::TomlDataStorage, path;
+                      write=false, read=!write, kws...)
+    if write
+        error("Embedded data is read-only from within the DataSets interface")
+    end
+    try
+        str = _getpath(storage, path)
+        !isnothing(str) || KeyError(path)
+        base64decode(str::AbstractString)
+    catch
+        error("TOML storage requires data to be as base64 encoded strings")
+    end
+end
+
+@! function Base.open(::Type{IO}, storage::TomlDataStorage, path; kws...)
+    buf = @! open(Vector{UInt8}, storage, path; kws...)
+    IOBuffer(buf)
+end
+
+
+# TODO: The following should be factored out and implemented generically
+function Base.read(storage::TomlDataStorage, path::RelPath, ::Type{T}) where {T}
+    @context begin
+        io = @! open(IO, storage, path)
+        read(io, T)
+    end
+end
+
+function Base.read(storage::TomlDataStorage, path::RelPath)
+    @context @! open(Vector{UInt8}, storage, path)
+end
+
+
+#-------------------------------------------------------------------------------
+# Connect storage backend
+function connect_toml_data_storage(f, config, dataset)
+    type = config["type"]
+    if type ∉ ("Blob", "BlobTree")
+        throw(ArgumentError("DataSet type $type not supported for data embedded in Data.toml"))
+    end
+    data = get(config, "data", nothing)
+    if type == "Blob"
+        if !(data isa AbstractString)
+            error("TOML data storage requires string data in the \"storage.data\" key")
+        end
+        f(Blob(TomlDataStorage(dataset, data)))
+    else
+        if !(data isa AbstractDict)
+            error("TOML data storage requires a dictionary in the \"storage.data\" key")
+        end
+        f(BlobTree(TomlDataStorage(dataset, data)))
+    end
+end
+
+add_storage_driver("TomlDataStorage"=>connect_toml_data_storage)
+

--- a/src/filesystem.jl
+++ b/src/filesystem.jl
@@ -74,6 +74,26 @@ Base.read(root::AbstractFileSystemRoot, path::RelPath) =
     read(sys_abspath(root, path))
 
 #--------------------------------------------------
+"""
+
+## Metadata spec
+
+For Blob:
+```
+    [datasets.storage]
+    driver="FileSystem"
+    type="Blob"
+    path=\$(path_to_file)
+```
+
+For BlobTree:
+```
+    [datasets.storage]
+    driver="FileSystem"
+    type="BlobTree"
+    path=\$(path_to_directory)
+```
+"""
 struct FileSystemRoot <: AbstractFileSystemRoot
     path::String
     read::Bool

--- a/test/Data.toml
+++ b/test/Data.toml
@@ -23,7 +23,6 @@ uuid="b498f769-a7f6-4f67-8d74-40b770398f26"
     # type="text"
     # parameters={encoding="UTF-8"}
 
-
 #--------------------------------------------------
 [[datasets]]
 description="Gzipped CSV example"
@@ -54,4 +53,44 @@ uuid="e7fd7080-e346-4a68-9ca9-98593a99266a"
     path="@__DIR__/data/csvset"
 
     # TODO: Add data maps here which expose it logically as a single CSV?
+
+
+#--------------------------------------------------
+[[datasets]]
+description="A data blob embedded in the TOML"
+name="embedded_blob"
+uuid="b498f769-a7f6-4f67-8d74-40b770398f26"
+
+    [datasets.storage]
+    driver="TomlDataStorage"
+    type="Blob"
+    data="AAAAAAAARUA="
+
+
+[[datasets]]
+description="A data tree embedded in the TOML"
+name="embedded_tree"
+uuid="b498f769-a7f6-4f67-8d74-40b770398f26"
+
+    [datasets.storage]
+    driver="TomlDataStorage"
+    type="BlobTree"
+
+# TOML.print(Dict("datasets"=>[Dict("storage"=>Dict("data"=>Dict(["d0$i"=>Dict(["$x.txt"=>base64encode("$i $x content") for x in ("a","b")]...) for i in 1:4]...)))]))
+
+        [datasets.storage.data.d01]
+        "b.txt" = "MSBiIGNvbnRlbnQ="
+        "a.txt" = "MSBhIGNvbnRlbnQ="
+
+        [datasets.storage.data.d02]
+        "b.txt" = "MiBiIGNvbnRlbnQ="
+        "a.txt" = "MiBhIGNvbnRlbnQ="
+
+        [datasets.storage.data.d03]
+        "b.txt" = "MyBiIGNvbnRlbnQ="
+        "a.txt" = "MyBhIGNvbnRlbnQ="
+
+        [datasets.storage.data.d04]
+        "b.txt" = "NCBiIGNvbnRlbnQ="
+        "a.txt" = "NCBhIGNvbnRlbnQ="
 

--- a/test/DataTomlStorage.jl
+++ b/test/DataTomlStorage.jl
@@ -1,0 +1,49 @@
+
+@testset "open() for DataSet" begin
+    proj = DataSets.load_project("Data.toml")
+
+    blob_ds = dataset(proj, "embedded_blob")
+    @test open(blob_ds) isa Blob
+    @test open(String, blob_ds) == "\0\0\0\0\0\0E@"
+    @test read(open(blob_ds), Float64) === 42.0
+
+    @test open(IO, blob_ds) do io
+        read(io, String)
+    end == "\0\0\0\0\0\0E@"
+
+    @context begin
+        @test @!(open(String, blob_ds)) == "\0\0\0\0\0\0E@"
+
+        blob = @! open(blob_ds)
+        @test blob isa Blob
+        @test @!(open(String, blob)) == "\0\0\0\0\0\0E@"
+
+        @test read(blob, Float64) === 42.0
+        @test read(blob) == UInt8[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x45, 0x40]
+    end
+
+    tree_ds = dataset(proj, "embedded_tree")
+    @test open(tree_ds) isa BlobTree
+    @test open(String, open(tree_ds)[path"d01/a.txt"]) == "1 a content"
+    @test open(String, open(tree_ds)[path"d02/b.txt"]) == "2 b content"
+    @context begin
+        tree = @! open(tree_ds)
+        @test tree isa BlobTree
+
+        @test isdir(tree)
+        @test !isfile(tree)
+
+        @test readdir(tree) == ["d01", "d02", "d03", "d04"]
+        @test readdir(tree["d01"]) == ["a.txt", "b.txt"]
+
+        @test !isdir(tree[path"d01/a.txt"])
+        @test isfile(tree[path"d01/a.txt"])
+
+        @test_throws ErrorException tree[path"nonexistent/a/b"]
+        @test_throws ErrorException tree["nonexistent"]
+
+        @test @!(open(String, tree[path"d01/a.txt"])) == "1 a content"
+        @test @!(open(String, tree[path"d02/b.txt"])) == "2 b content"
+    end
+end
+

--- a/test/projects.jl
+++ b/test/projects.jl
@@ -16,13 +16,13 @@ using DataSets:
     @test isnothing(get(proj, "nonexistent_data", nothing))
 
     # keys
-    @test sort(collect(keys(proj))) == ["a_table", "a_text_file", "a_tree_example"]
+    @test sort(collect(keys(proj))) == ["a_table", "a_text_file", "a_tree_example", "embedded_blob", "embedded_tree"]
     @test haskey(proj, "a_text_file")
     @test !haskey(proj, "nonexistent_data")
 
     # iteration
-    @test sort(getproperty.(collect(proj), :name)) == ["a_table", "a_text_file", "a_tree_example"]
-    @test sort(first.(pairs(proj))) == ["a_table", "a_text_file", "a_tree_example"]
+    @test sort(getproperty.(collect(proj), :name)) == ["a_table", "a_text_file", "a_tree_example", "embedded_blob", "embedded_tree"]
+    @test sort(first.(pairs(proj))) == ["a_table", "a_text_file", "a_tree_example", "embedded_blob", "embedded_tree"]
 
     # identity
     @test project_name(proj) == abspath("Data.toml")
@@ -99,7 +99,7 @@ end
     push!(proj, TomlFileDataProject(joinpath(@__DIR__, "active_project", "Data.toml")))
     push!(proj, TomlFileDataProject(joinpath(@__DIR__, "Data.toml")))
 
-    @test sort(collect(keys(proj))) == ["a_table", "a_text_file", "a_tree_example"]
+    @test sort(collect(keys(proj))) == ["a_table", "a_text_file", "a_tree_example", "embedded_blob", "embedded_tree"]
     # Data "a_text_file" should be found in the first project in the stack,
     # overriding the data of the same name in the second project.
     @test proj["a_text_file"].uuid == UUID("314996ef-12be-40d0-912c-9755af354fdb")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,3 +162,5 @@ end
 end
 
 include("projects.jl")
+
+include("DataTomlStorage.jl")


### PR DESCRIPTION
* Blobs are stored as base64 encoded strings
* Trees are stored as dictionaries

While we're at it, start to clean up storage backend interface.

Also deprecate `abspath(::RelPath)` depending on `pwd()`, as the
assumption that this refers to the filesystem, and that depending on the
global `pwd()` is actually reasonable seem pretty dubious in hindsight.

CC @fonsp — here's a storage driver for base64 data embedded within the Data.toml!
