### PR TITLE
Revive the data REPL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.3"
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
 ResourceContexts = "8d208092-d35c-4dd3-a0d7-8325f9cce6b4"

--- a/src/DataSets.jl
+++ b/src/DataSets.jl
@@ -321,7 +321,11 @@ function Base.show(io::IO, ::MIME"text/plain", project::AbstractDataProject)
     maxwidth = maximum(textwidth.(first.(sorted)))
     for (i, (name, data)) in enumerate(sorted)
         pad = maxwidth - textwidth(name)
-        print(io, "  ", name, ' '^pad, " => ", data.uuid)
+        storagetype = get(data.storage, "type", nothing)
+        icon = storagetype == "Blob"     ? '📄' :
+               storagetype == "BlobTree" ? '📁' :
+               '❓'
+        print(io, "  ", icon, ' ', name, ' '^pad, " => ", data.uuid)
         if i < length(sorted)
             println(io)
         end
@@ -577,6 +581,6 @@ include("DataTomlStorage.jl")
 # include("GitTree.jl")
 
 # Application-level stuff
-# include("repl.jl")
+include("repl.jl")
 
 end

--- a/src/DataSets.jl
+++ b/src/DataSets.jl
@@ -379,6 +379,8 @@ end
 # API for manipulating the stack.
 Base.push!(stack::StackedDataProject, project) = push!(stack.projects, project)
 Base.pushfirst!(stack::StackedDataProject, project) = pushfirst!(stack.projects, project)
+Base.popfirst!(stack::StackedDataProject) = popfirst!(stack.projects)
+Base.pop!(stack::StackedDataProject) = pop!(stack.projects)
 Base.empty!(stack::StackedDataProject) = empty!(stack.projects)
 
 function Base.show(io::IO, mime::MIME"text/plain", stack::StackedDataProject)
@@ -409,6 +411,14 @@ function expand_project_path(path)
     path
 end
 
+function data_project_from_path(path)
+    if path == "@"
+        project = ActiveDataProject()
+    else
+        project = TomlFileDataProject(expand_project_path(path))
+    end
+end
+
 function create_project_stack(env)
     stack = []
     env_search_path = get(env, "JULIA_DATASETS_PATH", nothing)
@@ -418,11 +428,7 @@ function create_project_stack(env)
         paths = split(env_search_path, Sys.iswindows() ? ';' : ':')
     end
     for path in paths
-        if path == "@"
-            project = ActiveDataProject()
-        else
-            project = TomlFileDataProject(expand_project_path(path))
-        end
+        project = data_project_from_path(path)
         push!(stack, project)
     end
     StackedDataProject(stack)

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -1,81 +1,185 @@
-"""
-    `DataSets.DataApp` contains all `DataSets` "application level" code and state.
+module Repl
 
-This includes the builtin REPL utilities and the default data project for use
-within a julia session.
+using Markdown
 
-In contrast, the main `DataSets` module includes only core data structures and
-operations which don't depend on global state.
+_data_repl_help = md"""
+## DataSets Data REPL
+
+|   Command    | Alias | Action |
+|:----------   |:----- | :---------- |
+| `list`       | `ls`  | List all datasets by name |
+| `show $name` |       | Show the content of dataset `$name` |
+| `help`      | `?` | Show this message |
+| `addproject` |       | Add a data project to the current stack |
+
 """
-module DataApp
 
 using ..DataSets
-import ..DataSets: DataSet, DataProject, link_dataset, load_project
 
-using REPL: LineEdit
-using URIs
+using ResourceContexts
+
+using REPL
 using ReplMaker
+# using URIs
 
-# Possible REPL verbs
-#
-# Adding
-#   add link - Create a new association between external data and the project
-#   add new  - Add a new dataset *within* the project
-#
-# Removing
-#   rm [link]   - Unlink the dataset from the project
-#   rm ! <name> - Remove the dataset from the project, and remove the actual
-#                 data too if it's embedded.
-#
-# open - REPL data viewer (?)
-# list - 
+# hex dump in xxd format
+function hexdump(out_stream, buf; groups_per_line=8, group_size=2)
+    linesize = groups_per_line*group_size
+    for line = 1:div(length(buf), linesize, RoundUp)
+        linebuf = buf[(line-1)*linesize+1 : min(line*linesize,end)]
+        address = (line-1)*linesize
+        print(out_stream, string(address, base=16, pad=4), ": ")
+        for group = 1:groups_per_line
+            for i=1:group_size
+                j = (group-1)*group_size+i
+                if j <= length(linebuf)
+                    print(out_stream, string(linebuf[j], base=16, pad=2))
+                else
+                    print(out_stream, "  ")
+                end
+            end
+            print(out_stream, ' ')
+        end
+        print(out_stream, ' ')
+        for j = 1:linesize
+            c = Char(j <= length(linebuf) ? linebuf[j] : ' ')
+            print(out_stream, isprint(c) ? c : '.')
+        end
+        print(out_stream, '\n')
+    end
+end
+
+struct DataCompletionProvider <: REPL.LineEdit.CompletionProvider
+end
+
+# function split_command(str)
+#     token_ranges = []
+#     i = 1
+#     while true
+#         rng = findnext(r"[^\s]+", full, i)
+#         !isnothing(rng) || break
+#         push!(token_ranges, rng)
+#         i = last(rng)+1
+#     end
+#     tokens = getindex.(full, token_ranges)
+#     token_ranges, tokens
+# end
+
+function REPL.complete_line(provider::DataCompletionProvider,
+                            state::REPL.LineEdit.PromptState)::
+                            Tuple{Vector{String},String,Bool}
+    # See REPL.jl complete_line(c::REPLCompletionProvider, s::PromptState)
+    partial = REPL.beforecursor(state.input_buffer)
+    full = REPL.LineEdit.input_string(state)
+    if partial != full
+        # For now, only complete at end of line
+        return ([], "", false)
+    end
+    tokens = split(full, r" +", keepempty=true)
+    if length(tokens) == 1
+        # Completions for basic commands
+        completions = String[]
+        for cmdset in [("list","ls"), ("show",), ("addproject",)]
+            for cmd in cmdset
+                if cmd == tokens[1]
+                    # Space after full length command
+                    return ([" "], "", true)
+                end
+                if startswith(cmd, tokens[1])
+                    push!(completions, cmd*" ")
+                    break
+                end
+            end
+        end
+        return (completions, tokens[1], !isempty(completions))
+    end
+    cmd = popfirst!(tokens)
+    if cmd == "show" && length(tokens) <= 1
+        tok_prefix = isempty(tokens) ? "" : tokens[1]
+        completions = String[]
+        ks = sort!(collect(keys(DataSets.PROJECT)))
+        for k in ks
+            if startswith(k, tok_prefix) && k != tok_prefix
+                push!(completions, k)
+            end
+        end
+        return (completions, tok_prefix, !isempty(completions))
+    end
+    return ([], "", false)
+end
 
 # Translate `data>` REPL syntax into an Expr to be evaluated in the REPL
 # backend.
 function make_data_repl_command(cmdstr)
     # Use shell tokenization rules for familiarity
-    cmd_tokens = Base.shell_split(cmdstr)
-    cmdname = cmd_tokens[1]
-    if cmdname in ("ln", "link")
-        # FIXME: Test :incomplete
-        if length(cmd_tokens) < 3
-            return Expr(:incomplete, "Needs name and location")
-        end
-        name = cmd_tokens[2]
-        location = cmd_tokens[3]
-        toks = cmd_tokens[4:end]
-        if any(toks[1:2:end] .!= "|")
-            error("Expected '|' separated layers after $location. Got $toks.")
-        end
-        layers = toks[2:2:end]
-        return quote
-            name = $name
-            location = DataSets.DataApp.expand_location($location)
-            layers = DataSets.DataApp.expand_layer.($layers)
-            d = DataSets.DataSet(default_name=name, location=location, layers=layers)
-            DataSets.link_dataset(DataSets.DataApp._current_project, name=>d)
-            d
-        end
-    elseif cmdname == "unlink"
-        name = cmd_tokens[2]
-        return quote
-            DataSets.unlink_dataset(DataSets.DataApp._current_project, $name)
-            nothing
-        end
-    elseif cmdname in ("ls", "list")
+    tokens = Base.shell_split(cmdstr)
+    cmd = tokens[1]
+    popfirst!(tokens)
+    if cmd in ("ls", "list")
         return quote
             # Will be `show()`n by the REPL
-            DataSets.DataApp._current_project
+            DataSets.PROJECT
         end
-    elseif cmdname == "show"
-        error("Not implemented")
-        # Idea here could be to open a browser for the data.
+    elseif cmd == "addproject"
+        path = tokens[1]
+        return quote
+            proj = $DataSets.TomlFileDataProject($path)
+            pushfirst!($DataSets.PROJECT, proj)
+            proj
+        end
+    elseif cmd == "show"
+        name = tokens[1]
+        return quote
+            $Repl.show_dataset($name)
+        end
+    elseif cmd in ("help", "?")
+        return _data_repl_help
     else
         error("Invalid data REPL syntax: \"$cmdstr\"")
     end
 end
 
-function init_repl(; start_key = ">")
+function show_dataset(name)
+    out_stream = stdout
+    @context begin
+        data = @! open(dataset(name))
+        _show_dataset(out_stream, data)
+    end
+end
+
+function _show_dataset(out_stream::IO, blob::Blob)
+    @context begin
+        io = @! open(IO, blob)
+        N = 1024
+        buf = read(io, N)
+        str = String(copy(buf))
+        n_textlike = count(str) do c
+            isvalid(c) || return false
+            isprint(c) || c in ('\n', '\r', '\t')
+        end
+        if n_textlike / length(str) > 0.95
+            # It's approximately UTF-8 encoded text data.
+            print(out_stream, str)
+        else
+            # It's something else, perhaps binary or another text
+            # encoding. Do a hex dump instead.
+            hexdump(out_stream, buf)
+        end
+        if !eof(io)
+            println(out_stream, "…")
+        end
+    end
+end
+
+function _show_dataset(out_stream::IO, tree::BlobTree)
+    show(out_stream, MIME("text/plain"), tree)
+end
+
+function _show_dataset(out_stream::IO, x)
+    show(out_stream, MIME("text/plain"), x)
+end
+
+function init_data_repl(; start_key = ">")
     ReplMaker.initrepl(make_data_repl_command,
                        repl = Base.active_repl,
                        # valid_input_checker = Support for multiple lines syntax?
@@ -84,42 +188,13 @@ function init_repl(; start_key = ">")
                        start_key = start_key,
                        sticky_mode=true,
                        mode_name = "Data_Manager",
-                       startup_text=false)
+                       completion_provider = DataCompletionProvider(),
+                       startup_text=true)
     nothing
 end
 
-link_dataset(name_and_data::Pair) = link_dataset(_current_project, name_and_data)
-
-function repl_link_dataset(name, accessors)
-    @assert length(accessors) == 1
-    uri = URI(accessors[1])
-    d = DataSet(name=name, location=uri)
-    link_dataset(d)
-end
-
-function list_datasets(io, proj::DataProject)
-    for (name,d) in proj.datasets
-        println(io, name, " @ ", d.location)
-    end
-end
-
-function expand_location(location)
-    path = abspath(location)
-    if ispath(path)
-        uri = URI("file", "", 0, path)
-    else
-        uri = URI(location)
-    end
-end
-
-function expand_layer(layer)
-    # TODO: expand the short REPL syntax into layer objects?
-    layer
-end
-
-
 function __init__()
-    init_repl()
+    isinteractive() && init_data_repl()
 end
 
 end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -129,6 +129,16 @@ function complete_command_list(cmd_prefix, commands)
     return completions
 end
 
+function path_str(path_completion)
+    path = REPL.REPLCompletions.completion_text(path_completion)
+    if Sys.iswindows()
+        # On windows, REPLCompletions.complete_path() adds extra escapes for
+        # use within a normal string in the Juila REPL but we don't need those.
+        path = replace(path, "\\\\"=>'\\')
+    end
+    return path
+end
+
 function complete(str_to_complete)
     tokens = split(str_to_complete, r" +", keepempty=true)
     cmd = popfirst!(tokens)
@@ -171,7 +181,7 @@ function complete(str_to_complete)
                 path_prefix = isempty(tokens) ? "" : tokens[1]
                 (path_completions, range, should_complete) =
                     REPL.REPLCompletions.complete_path(path_prefix, length(path_prefix))
-                completions = [REPL.REPLCompletions.completion_text(c) for c in path_completions]
+                completions = [path_str(c) for c in path_completions]
                 return (completions, path_prefix[range], should_complete)
             end
         end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -1,16 +1,19 @@
-module Repl
+module DataREPL
 
 using Markdown
 
 _data_repl_help = md"""
 ## DataSets Data REPL
 
-|   Command    | Alias | Action |
-|:----------   |:----- | :---------- |
-| `list`       | `ls`  | List all datasets by name |
-| `show $name` |       | Show the content of dataset `$name` |
-| `help`      | `?` | Show this message |
-| `addproject` |       | Add a data project to the current stack |
+|   Command    | Alias     | Action      |
+|:----------   |:--------- | :---------- |
+| `help`       | `?`       | Show this message |
+| `list`       | `ls`      | List all datasets by name |
+| `show $name` |           | Show the content of dataset `$name` |
+| `stack` | `st`           | Manipulate the global data search stack |
+| `stack list` | `st ls`   | List all projects in the global data search stack |
+| `stack push $path` | `st push` | Add data project `$path` to front of the search stack |
+| `stack pop`  | `st pop`  | Remove data project from front of the search stack    |
 
 """
 
@@ -21,6 +24,16 @@ using ResourceContexts
 using REPL
 using ReplMaker
 # using URIs
+
+#-------------------------------------------------------------------------------
+# Utilities for browsing dataset content
+function show_dataset(name)
+    out_stream = stdout
+    @context begin
+        data = @! open(dataset(name))
+        _show_dataset(out_stream, data)
+    end
+end
 
 # hex dump in xxd format
 function hexdump(out_stream, buf; groups_per_line=8, group_size=2)
@@ -46,104 +59,6 @@ function hexdump(out_stream, buf; groups_per_line=8, group_size=2)
             print(out_stream, isprint(c) ? c : '.')
         end
         print(out_stream, '\n')
-    end
-end
-
-struct DataCompletionProvider <: REPL.LineEdit.CompletionProvider
-end
-
-# function split_command(str)
-#     token_ranges = []
-#     i = 1
-#     while true
-#         rng = findnext(r"[^\s]+", full, i)
-#         !isnothing(rng) || break
-#         push!(token_ranges, rng)
-#         i = last(rng)+1
-#     end
-#     tokens = getindex.(full, token_ranges)
-#     token_ranges, tokens
-# end
-
-function REPL.complete_line(provider::DataCompletionProvider,
-                            state::REPL.LineEdit.PromptState)::
-                            Tuple{Vector{String},String,Bool}
-    # See REPL.jl complete_line(c::REPLCompletionProvider, s::PromptState)
-    partial = REPL.beforecursor(state.input_buffer)
-    full = REPL.LineEdit.input_string(state)
-    if partial != full
-        # For now, only complete at end of line
-        return ([], "", false)
-    end
-    tokens = split(full, r" +", keepempty=true)
-    if length(tokens) == 1
-        # Completions for basic commands
-        completions = String[]
-        for cmdset in [("list","ls"), ("show",), ("addproject",)]
-            for cmd in cmdset
-                if cmd == tokens[1]
-                    # Space after full length command
-                    return ([" "], "", true)
-                end
-                if startswith(cmd, tokens[1])
-                    push!(completions, cmd*" ")
-                    break
-                end
-            end
-        end
-        return (completions, tokens[1], !isempty(completions))
-    end
-    cmd = popfirst!(tokens)
-    if cmd == "show" && length(tokens) <= 1
-        tok_prefix = isempty(tokens) ? "" : tokens[1]
-        completions = String[]
-        ks = sort!(collect(keys(DataSets.PROJECT)))
-        for k in ks
-            if startswith(k, tok_prefix) && k != tok_prefix
-                push!(completions, k)
-            end
-        end
-        return (completions, tok_prefix, !isempty(completions))
-    end
-    return ([], "", false)
-end
-
-# Translate `data>` REPL syntax into an Expr to be evaluated in the REPL
-# backend.
-function make_data_repl_command(cmdstr)
-    # Use shell tokenization rules for familiarity
-    tokens = Base.shell_split(cmdstr)
-    cmd = tokens[1]
-    popfirst!(tokens)
-    if cmd in ("ls", "list")
-        return quote
-            # Will be `show()`n by the REPL
-            DataSets.PROJECT
-        end
-    elseif cmd == "addproject"
-        path = tokens[1]
-        return quote
-            proj = $DataSets.TomlFileDataProject($path)
-            pushfirst!($DataSets.PROJECT, proj)
-            proj
-        end
-    elseif cmd == "show"
-        name = tokens[1]
-        return quote
-            $Repl.show_dataset($name)
-        end
-    elseif cmd in ("help", "?")
-        return _data_repl_help
-    else
-        error("Invalid data REPL syntax: \"$cmdstr\"")
-    end
-end
-
-function show_dataset(name)
-    out_stream = stdout
-    @context begin
-        data = @! open(dataset(name))
-        _show_dataset(out_stream, data)
     end
 end
 
@@ -179,17 +94,164 @@ function _show_dataset(out_stream::IO, x)
     show(out_stream, MIME("text/plain"), x)
 end
 
+
+#-------------------------------------------------------------------------------
+# REPL command handling and completions
+
+# function split_command(str)
+#     token_ranges = []
+#     i = 1
+#     while true
+#         rng = findnext(r"[^\s]+", full, i)
+#         !isnothing(rng) || break
+#         push!(token_ranges, rng)
+#         i = last(rng)+1
+#     end
+#     tokens = getindex.(full, token_ranges)
+#     token_ranges, tokens
+# end
+
+function complete_command_list(cmd_prefix, commands)
+    # Completions for basic commands
+    completions = String[]
+    for cmdset in commands
+        for cmd in cmdset
+            if cmd == cmd_prefix
+                # Space after full length command
+                return ([" "], "", true)
+            end
+            if startswith(cmd, cmd_prefix)
+                push!(completions, cmd*" ")
+                break
+            end
+        end
+    end
+    return completions
+end
+
+function complete(str_to_complete)
+    tokens = split(str_to_complete, r" +", keepempty=true)
+    cmd = popfirst!(tokens)
+    if isempty(tokens)
+        # Completions for basic commands
+        completions = complete_command_list(cmd, [
+            ("list","ls"),
+            ("show",),
+            ("stack",),
+            ("help","?")
+        ])
+        # Empty completion => return anyway to show user their prefix is wrong
+        return (completions, cmd, !isempty(completions))
+    end
+    if cmd == "show"
+        if length(tokens) <= 1
+            name_prefix = isempty(tokens) ? "" : tokens[1]
+            completions = String[]
+            ks = sort!(collect(keys(DataSets.PROJECT)))
+            for k in ks
+                if startswith(k, name_prefix) && k != name_prefix
+                    push!(completions, k)
+                end
+            end
+            return (completions, name_prefix, !isempty(completions))
+        end
+    elseif cmd == "stack"
+        if length(tokens) <= 1
+            subcmd_prefix = isempty(tokens) ? "" : tokens[1]
+            # Completions for project stack subcommands
+            completions = complete_command_list(subcmd_prefix, [
+                ("push",),
+                ("pop",),
+                ("list","ls",)
+            ])
+            return (completions, tokens[1], !isempty(completions))
+        elseif length(tokens) == 2
+            subcmd = popfirst!(tokens)
+            if subcmd == "push"
+                path_prefix = isempty(tokens) ? "" : tokens[1]
+                (path_completions, range, should_complete) =
+                    REPL.REPLCompletions.complete_path(path_prefix, length(path_prefix))
+                completions = [REPL.REPLCompletions.completion_text(c) for c in path_completions]
+                return (completions, path_prefix[range], should_complete)
+            end
+        end
+    end
+    return ([], "", false)
+end
+
+# Translate `data>` REPL syntax into an Expr to be evaluated in the REPL
+# backend.
+function parse_data_repl_cmd(cmdstr)
+    # Use shell tokenization rules for familiarity
+    tokens = Base.shell_split(cmdstr)
+    cmd = tokens[1]
+    popfirst!(tokens)
+    if cmd in ("list", "ls")
+        return quote
+            $DataSets.DataProject(Dict(pairs($DataSets.PROJECT)))
+        end
+    elseif cmd == "stack" && length(tokens) >= 1
+        subcmd = popfirst!(tokens)
+        if subcmd == "push"
+            path = popfirst!(tokens)
+            return quote
+                proj = $DataSets.data_project_from_path($path)
+                stack = $DataSets.PROJECT
+                pushfirst!(stack, proj)
+                stack
+            end
+        elseif subcmd == "pop"
+            return quote
+                stack = $DataSets.PROJECT
+                popfirst!(stack)
+                stack
+            end
+        elseif subcmd in ("list", "ls")
+            return quote
+                $DataSets.PROJECT
+            end
+        end
+    elseif cmd == "show"
+        name = tokens[1]
+        return quote
+            $DataREPL.show_dataset($name)
+        end
+    elseif cmd in ("help", "?")
+        return _data_repl_help
+    end
+    error("Invalid data REPL syntax: \"$cmdstr\"")
+end
+
+
+#-------------------------------------------------------------------------------
+# Integration with REPL / ReplMaker
+struct DataCompletionProvider <: REPL.LineEdit.CompletionProvider
+end
+
+function REPL.complete_line(provider::DataCompletionProvider,
+                            state::REPL.LineEdit.PromptState)::
+                            Tuple{Vector{String},String,Bool}
+    # See REPL.jl complete_line(c::REPLCompletionProvider, s::PromptState)
+    partial = REPL.beforecursor(state.input_buffer)
+    full = REPL.LineEdit.input_string(state)
+    if partial != full
+        # For now, only complete at end of line
+        return ([], "", false)
+    end
+    complete(full)
+end
+
 function init_data_repl(; start_key = ">")
-    ReplMaker.initrepl(make_data_repl_command,
+    ReplMaker.initrepl(parse_data_repl_cmd,
                        repl = Base.active_repl,
                        # valid_input_checker = Support for multiple lines syntax?
                        prompt_text = "data> ",
                        prompt_color = :red,
                        start_key = start_key,
-                       sticky_mode=true,
-                       mode_name = "Data_Manager",
+                       sticky_mode = true,
+                       mode_name = "DataSets",
                        completion_provider = DataCompletionProvider(),
-                       startup_text=true)
+                       startup_text = true)
     nothing
 end
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -6,7 +6,11 @@ using DataSets.DataREPL: complete, parse_data_repl_cmd
     @test complete("stack ") == (["push ", "pop ", "list "], "", true)
 
     cd(@__DIR__) do
-        @test complete("stack push da") == (["data/"], "da", true)
+        if Sys.iswindows()
+            @test complete("stack push da") == (["data\\"], "da", true)
+        else
+            @test complete("stack push da") == (["data/"], "da", true)
+        end
     end
 end
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -1,0 +1,31 @@
+using DataSets.DataREPL: complete, parse_data_repl_cmd
+
+@testset "repl completions" begin
+    @test complete("") == (["list ", "show ", "stack ", "help "], "", true)
+    @test complete("s") == (["show ", "stack "], "s", true)
+    @test complete("stack ") == (["push ", "pop ", "list "], "", true)
+
+    cd(@__DIR__) do
+        @test complete("stack push da") == (["data/"], "da", true)
+    end
+end
+
+@testset "repl commands" begin
+    @test eval(parse_data_repl_cmd("help")) === DataSets.DataREPL._data_repl_help
+    @test eval(parse_data_repl_cmd("?")) === DataSets.DataREPL._data_repl_help
+    empty!(DataSets.PROJECT)
+    @test eval(parse_data_repl_cmd("stack push $(@__DIR__)")) === DataSets.PROJECT
+    @test length(DataSets.PROJECT.projects) == 1
+    @test eval(parse_data_repl_cmd("stack pop")) === DataSets.PROJECT
+    @test isempty(DataSets.PROJECT.projects)
+end
+
+@testset "data show utils" begin
+    @test sprint(DataSets.DataREPL.hexdump, UInt8.(0:70)) == raw"""
+    0000: 0001 0203 0405 0607 0809 0a0b 0c0d 0e0f  ................
+    0010: 1011 1213 1415 1617 1819 1a1b 1c1d 1e1f  ................
+    0020: 2021 2223 2425 2627 2829 2a2b 2c2d 2e2f   !"#$%&'()*+,-./
+    0030: 3031 3233 3435 3637 3839 3a3b 3c3d 3e3f  0123456789:;<=>?
+    0040: 4041 4243 4445 46                        @ABCDEF         
+    """
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,6 +161,7 @@ end
     @test isfile(DataSets.sys_abspath(temptree["d1"]["hi_2.txt"]))
 end
 
+include("repl.jl")
 include("projects.jl")
 include("DataTomlStorage.jl")
 include("backend_compat.jl")


### PR DESCRIPTION
Basic support for:
* Listing datasets in the global data project stack with `ls`,`list`
* Showing the content of datasets with `show`
* ~~Adding to the global project stack with `addproject`~~
* Manipulate the global data project stack with `stack list`, `stack push`, `stack pop`
* Help with `help`/`?`

Includes REPL completions, help text and some tests.