### PR TITLE
Use `/` as separator for dataset namespaces

### DIFF
--- a/docs/src/Data.toml
+++ b/docs/src/Data.toml
@@ -1,5 +1,5 @@
 # Version of the data TOML format.
-data_config_version=0
+data_config_version=1
 
 [[datasets]]
 # Some alphanumeric name (can include spaces and underscores)

--- a/test/Data.toml
+++ b/test/Data.toml
@@ -1,5 +1,5 @@
 # This specifies the version of the Data.toml configuration
-data_config_version=0
+data_config_version=1
 
 # The following is an array of the actual `DataSet`s.
 
@@ -22,6 +22,16 @@ uuid="b498f769-a7f6-4f67-8d74-40b770398f26"
     # [[datasets.maps]]
     # type="text"
     # parameters={encoding="UTF-8"}
+
+[[datasets]]
+description="A text file with namespace"
+name="some_namespace/a_text_file"
+uuid="b498f769-a7f6-4f67-8d74-40b770398f26"
+
+    [datasets.storage]
+    driver="FileSystem"
+    type="Blob"
+    path="@__DIR__/data/file.txt"
 
 #--------------------------------------------------
 [[datasets]]

--- a/test/DriverAutoloadData.toml
+++ b/test/DriverAutoloadData.toml
@@ -1,4 +1,4 @@
-data_config_version = 0
+data_config_version = 1
 
 [[datasets]]
 description="Test dynamic loading of drivers"

--- a/test/projects.jl
+++ b/test/projects.jl
@@ -14,7 +14,8 @@ test_project_names = ["a_table",
                       "embedded_blob",
                       "embedded_tree",
                       "old_backend_blob",
-                      "old_backend_tree"]
+                      "old_backend_tree",
+                      "some_namespace/a_text_file"]
 
 @testset "TomlFileDataProject" begin
     proj = TomlFileDataProject(abspath("Data.toml"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,12 +90,15 @@ end
     @test DataSets.check_dataset_name("a_b") === nothing
     @test DataSets.check_dataset_name("a1") === nothing
     @test DataSets.check_dataset_name("δεδομένα") === nothing
+    @test DataSets.check_dataset_name("a/b") === nothing
+    @test DataSets.check_dataset_name("a/b/c") === nothing
     # Invalid names
-    @test_throws ErrorException("DataSet name must start with a letter, and can only contain letters, numbers or underscores; got \"a/b\"") DataSets.check_dataset_name("a/b")
+    @test_throws ErrorException("DataSet name \"a?b\" is invalid. DataSet names must start with a letter and can contain only letters, numbers, `_` or `/`.") DataSets.check_dataset_name("a?b")
     @test_throws ErrorException DataSets.check_dataset_name("1")
     @test_throws ErrorException DataSets.check_dataset_name("a b")
     @test_throws ErrorException DataSets.check_dataset_name("a.b")
-    @test_throws ErrorException DataSets.check_dataset_name("a:b")
+    @test_throws ErrorException DataSets.check_dataset_name("a/b/")
+    @test_throws ErrorException DataSets.check_dataset_name("/a/b")
 end
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This is the obvious hierarchical separator, and consistent with having
URNs as an expanded form for dataset names (see RFC8141
https://datatracker.ietf.org/doc/html/rfc8141)

The only real downside is that it uses some syntax which might be nice
for a path component, but we could potentially use something like
`namespace/name:a/b/c` for that instead. Or perhaps the URN syntax if we can
put up with a bit of extra verbosity for some extra flexibility.