### PR TITLE
Add DataSets.PROJECT_VERSION

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataSets"
 uuid = "c9661210-8a83-48f0-b833-72e62abce419"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/DataSets.jl
+++ b/src/DataSets.jl
@@ -9,6 +9,14 @@ using Base: PkgId
 export DataSet, dataset, @datafunc, @datarun
 export Blob, BlobTree, newfile, newdir
 
+"""
+The current DataSets version number
+"""
+const PACKAGE_VERSION = let
+    project = TOML.parsefile(joinpath(pkgdir(DataSets), "Project.toml"))
+    VersionNumber(project["version"])
+end
+
 include("paths.jl")
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This allows backends to check the DataSets version without loading the
associated Project.toml