### PR TITLE
Flexible string-based data addressing with URL-like "dataspec"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataSets"
 uuid = "c9661210-8a83-48f0-b833-72e62abce419"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -17,7 +17,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 AbstractTrees = "0.3"
 ReplMaker = "0.2"
-ResourceContexts = "0.1"
+ResourceContexts = "0.1,0.2"
 TOML = "1"
 julia = "1.5"
 

--- a/src/filesystem.jl
+++ b/src/filesystem.jl
@@ -271,7 +271,7 @@ end
 #--------------------------------------------------
 
 # Filesystem storage driver
-function connect_filesystem(f, config, _)
+function connect_filesystem(f, config, dataset)
     path = config["path"]
     type = config["type"]
     if type == "Blob"
@@ -280,6 +280,10 @@ function connect_filesystem(f, config, _)
     elseif type == "BlobTree"
         isdir(path)  || throw(ArgumentError("$(repr(path)) should be a directory"))
         storage = BlobTree(FileSystemRoot(path))
+        path = dataspec_fragment_as_path(dataset)
+        if !isnothing(path)
+            storage = storage[path]
+        end
     else
         throw(ArgumentError("DataSet type $type not supported on the filesystem"))
     end


### PR DESCRIPTION
This parses the argument to dataset() with a URL-like scheme, enabling
more flexible naming of resources within a given dataset. Like URLs, we
use the & and # as separators for query and fragment sections.

Like URLs, this provides for a compact string representation which can
be easily communicated between users of a shared dataset to address
subresources without the need to create an entirely new and largely
duplicated dataset configuration.

As in URLs, the query section is to be used during resource resolution,
for example a version number for the dataset can be specified.  We
choose the standard & and = separators for key value pairs:

    name/of/dataset?version=v1

As in URLs, the fragment section refers to a subresource and its
interpretation depends on the type of the dataset. (In analogy, the
meaning of the fragment of a URL depends on the mime type received from
the server.) For example, a subtree of a BlobTree can be addressed using

    tree_name#path/to/subtree

The use of fragment for indexing a BlobTree is implemented here as one
handy use case of this syntax.

Closes #32 