### PR TITLE
show method for DataSet: add line at the top

### DIFF
--- a/src/DataSet.jl
+++ b/src/DataSet.jl
@@ -115,6 +115,8 @@ function Base.show(io::IO, d::DataSet)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", d::DataSet)
+    println(io, "DataSet instance:")
+    println(io)
     TOML.print(io, d.conf)
 end
 


### PR DESCRIPTION
The current show method does not reveal that we are looking at a DataSet type, it looks like a text/string object:

<img width="732" alt="Schermafbeelding 2022-04-08 om 14 34 27" src="https://user-images.githubusercontent.com/6933510/162436487-f3aa0a87-7bc8-4bca-9a96-71c69f65b9d6.png">
