### PR TITLE
Add DataSets.from_path(), allow `-` in dataset names

### DIFF
--- a/src/DataSet.jl
+++ b/src/DataSet.jl
@@ -59,7 +59,7 @@ function _check_keys(config, context, keys)
 end
 
 """
-    check_dataset_name(name)
+    is_valid_dataset_name(name)
 
 Check whether a dataset name is valid. Valid names include start with a letter
 and may contain letters, numbers or `_`. Names may be hieracicial, with pieces
@@ -70,19 +70,34 @@ separated with forward slashes. Examples:
     username/data
     organization/project/data
 """
-function check_dataset_name(name::AbstractString)
+function is_valid_dataset_name(name::AbstractString)
     # DataSet names disallow most punctuation for now, as it may be needed as
     # delimiters in data-related syntax (eg, for the data REPL).
     dataset_name_pattern = r"
         ^
         [[:alpha:]]
         (?:
-            [[:alnum:]_]      |
+            [-[:alnum:]_]     |
             / (?=[[:alpha:]])
         )*
         $
         "x
-    if !occursin(dataset_name_pattern, name)
+    return occursin(dataset_name_pattern, name)
+end
+
+function make_valid_dataset_name(name)
+    if !is_valid_dataset_name(name)
+        name = replace(name, r"^[^[:alpha:]]+"=>"")
+        name = replace(name, r"[^-[:alnum:]_/]"=>"_")
+        if !is_valid_dataset_name(name)
+            name = "data"
+        end
+    end
+    return name
+end
+
+function check_dataset_name(name::AbstractString)
+    if !is_valid_dataset_name(name)
         error("DataSet name \"$name\" is invalid. DataSet names must start with a letter and can contain only letters, numbers, `_` or `/`.")
     end
 end

--- a/src/DataSet.jl
+++ b/src/DataSet.jl
@@ -88,8 +88,10 @@ end
 function make_valid_dataset_name(name)
     if !is_valid_dataset_name(name)
         name = replace(name, r"^[^[:alpha:]]+"=>"")
+        name = replace(name, '\\'=>'/')
         name = replace(name, r"[^-[:alnum:]_/]"=>"_")
         if !is_valid_dataset_name(name)
+            # best-effort fallback
             name = "data"
         end
     end

--- a/src/file_data_projects.jl
+++ b/src/file_data_projects.jl
@@ -205,3 +205,35 @@ function _load_project(content::AbstractString, sys_data_dir)
     load_project(config)
 end
 
+#-------------------------------------------------------------------------------
+"""
+    from_path(path)
+
+Create a `DataSet` from a local filesystem path. The type of the dataset is
+inferred as a blob or tree based on whether the local path is a file or
+directory.
+"""
+function from_path(path::AbstractString)
+    dtype = isfile(path) ? "Blob"     :
+            isdir(path)  ? "BlobTree" :
+            nothing
+
+    if isnothing(dtype)
+        msg = ispath(path) ?
+            "Unrecognized data at path \"$path\"" :
+            "Path \"$path\" does not exist"
+        throw(ArgumentError(msg))
+    end
+
+    conf = Dict(
+        "name"=>make_valid_dataset_name(path),
+        "uuid"=>string(uuid4()),
+        "storage"=>Dict(
+            "driver"=>"FileSystem",
+            "type"=>dtype,
+            "path"=>abspath(path),
+        )
+    )
+
+    DataSet(conf)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,6 +119,16 @@ end
     @test !DataSets.is_valid_dataset_name("/a/b")
     # Error message for invalid names
     @test_throws ErrorException("DataSet name \"a?b\" is invalid. DataSet names must start with a letter and can contain only letters, numbers, `_` or `/`.") DataSets.check_dataset_name("a?b")
+
+    # Making valid names from path-like things
+    @test DataSets.make_valid_dataset_name("a/b") == "a/b"
+    @test DataSets.make_valid_dataset_name("a1") == "a1"
+    @test DataSets.make_valid_dataset_name("1a") == "a"
+    @test DataSets.make_valid_dataset_name("//a/b") == "a/b"
+    @test DataSets.make_valid_dataset_name("a..b") == "a__b"
+    @test DataSets.make_valid_dataset_name("C:\\a\\b") == "C_/a/b"
+    # fallback
+    @test DataSets.make_valid_dataset_name("a//b") == "data"
 end
 
 @testset "URL-like dataspec parsing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,17 @@ end
 end
 
 #-------------------------------------------------------------------------------
+@testset "from_path" begin
+    file_dataset = DataSets.from_path(joinpath(@__DIR__, "data", "file.txt"))
+    @test read(open(file_dataset), String) == "Hello world!\n"
+
+    dir_dataset = DataSets.from_path(joinpath(@__DIR__, "data", "csvset"))
+
+    @test open(dir_dataset) isa BlobTree
+    @test keys(open(dir_dataset)) == ["1.csv", "2.csv"]
+end
+
+#-------------------------------------------------------------------------------
 @testset "open() for Blob and BlobTree" begin
     blob = Blob(FileSystemRoot("data/file.txt"))
     @test        open(identity, String, blob)         == "Hello world!\n"
@@ -91,20 +102,23 @@ end
 end
 
 #-------------------------------------------------------------------------------
-@testset "Data set name parsing" begin
+@testset "Data set names" begin
     # Valid names
-    @test DataSets.check_dataset_name("a_b") === nothing
-    @test DataSets.check_dataset_name("a1") === nothing
-    @test DataSets.check_dataset_name("δεδομένα") === nothing
-    @test DataSets.check_dataset_name("a/b") === nothing
-    @test DataSets.check_dataset_name("a/b/c") === nothing
+    @test DataSets.is_valid_dataset_name("a_b")
+    @test DataSets.is_valid_dataset_name("a-b")
+    @test DataSets.is_valid_dataset_name("a1")
+    @test DataSets.is_valid_dataset_name("δεδομένα")
+    @test DataSets.is_valid_dataset_name("a/b")
+    @test DataSets.is_valid_dataset_name("a/b/c")
     # Invalid names
+    @test !DataSets.is_valid_dataset_name("1")
+    @test !DataSets.is_valid_dataset_name("a b")
+    @test !DataSets.is_valid_dataset_name("a.b")
+    @test !DataSets.is_valid_dataset_name("a/b/")
+    @test !DataSets.is_valid_dataset_name("a//b")
+    @test !DataSets.is_valid_dataset_name("/a/b")
+    # Error message for invalid names
     @test_throws ErrorException("DataSet name \"a?b\" is invalid. DataSet names must start with a letter and can contain only letters, numbers, `_` or `/`.") DataSets.check_dataset_name("a?b")
-    @test_throws ErrorException DataSets.check_dataset_name("1")
-    @test_throws ErrorException DataSets.check_dataset_name("a b")
-    @test_throws ErrorException DataSets.check_dataset_name("a.b")
-    @test_throws ErrorException DataSets.check_dataset_name("a/b/")
-    @test_throws ErrorException DataSets.check_dataset_name("/a/b")
 end
 
 @testset "URL-like dataspec parsing" begin


### PR DESCRIPTION
The from_path function can be used to create a standalone DataSet from
data on the local filesystem, inferring the type as file or directory.

Also allow `-` in dataset names: this should be harmless enough in terms
of our URL-like dataspec syntax, and also in the data REPL where
shell-like splitting treats `-` as part of words. This is particularly
useful on JuliaHub where we allow user names to contain `-`.