### PR TITLE
DataSet configuration

### DIFF
--- a/docs/src/Data.toml
+++ b/docs/src/Data.toml
@@ -16,8 +16,8 @@ uuid="b498f769-a7f6-4f67-8d74-40b770398f26"
     # Data stored in FileSystem is either File (a file) or FileTree (a directory/folder)
     type="File"
     # Path with posix `/` separators.
-    # Use @__DIR__ for paths relative to Data.toml
-    path="@__DIR__/data/file.txt"
+    # Relative paths are relative to the location of Data.toml
+    path="data/file.txt"
 
 # A second example
 [[datasets]]
@@ -28,7 +28,7 @@ uuid="e7fd7080-e346-4a68-9ca9-98593a99266a"
     [datasets.storage]
     driver="FileSystem"
     type="FileTree"
-    path="@__DIR__/data/csvset"
+    path="data/csvset"
 
 # Further datasets can be added as desired
 # [[datasets]]

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -3,12 +3,18 @@
 ## Using datasets
 
 The primary mechanism for loading datasets is the `dataset` function, coupled
-with `open()` to open the resulting `DataSet` as some Julia type. In addition,
-DataSets.jl provides two macros [`@datafunc`](@ref) and [`@datarun`](@ref) to
-help in creating program entry points and running them.
+with `open()` to open the resulting `DataSet` as some Julia type.
 
 ```@docs
 dataset
+```
+
+In addition, DataSets.jl provides two macros [`@datafunc`](@ref) and
+[`@datarun`](@ref) to help in creating program entry points and running them.
+Note that these APIs aren't fully formed and might be deprecated before
+DataSets-1.0.
+
+```@docs
 @datafunc
 @datarun
 ```
@@ -46,6 +52,14 @@ DataSets.ActiveDataProject
 DataSets.TomlFileDataProject
 ```
 
+### Modifying datasets
+
+The metadata for a dataset may be updated using `config!`
+
+```@docs
+DataSets.config!
+```
+
 ## Data Models for files and directories
 
 DataSets provides some builtin data models [`File`](@ref) and
@@ -62,7 +76,7 @@ newdir
 
 ## Storage Drivers
 
-To add a new kind of data storage backend, implement [`DataSets.add_storage_driver`](@ref)
+To add a new kind of data storage backend, call [`DataSets.add_storage_driver`](@ref)
 
 ```@docs
 DataSets.add_storage_driver

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -12,6 +12,7 @@ DocTestFilters = [
     r"path =.*",
     r"@.*",
     r"(?<=IOStream\().*",
+    r"(?<=TomlFileDataProject \[).*",
 ]
 ```
 
@@ -71,7 +72,7 @@ global configuration this is also possible:
 
 ```jldoctest
 julia> project = DataSets.load_project("src/Data.toml")
-DataSets.DataProject:
+DataSets.TomlFileDataProject [.../DataSets/docs/src/Data.toml]:
   📄 a_text_file    => b498f769-a7f6-4f67-8d74-40b770398f26
   📁 a_tree_example => e7fd7080-e346-4a68-9ca9-98593a99266a
 

--- a/src/DataSet.jl
+++ b/src/DataSet.jl
@@ -5,45 +5,20 @@ unopinionated about the underlying storage mechanism.
 The data in a `DataSet` has a type which implies an index; the index can be
 used to partition the data for processing.
 """
-struct DataSet
-    # For now, the representation `conf` contains data read directly from the
-    # TOML. Once the design has settled we might get some explicit fields and
-    # do validation.
+mutable struct DataSet
+    project        # AbstractDataProject owning this DataSet
     uuid::UUID     # Unique identifier for the dataset. Use uuid4() to create these.
+    # The representation `conf` contains "configuration data" read directly from
+    # the TOML (or other data project source, eg json API etc)
     conf
 
-    function DataSet(conf)
-        _check_keys(conf, DataSet, ["uuid"=>String, "storage"=>Dict, "name"=>String])
-        _check_keys(conf["storage"], DataSet, ["driver"=>String])
-        _check_optional_keys(conf,
-                             "description"=>AbstractString,
-                             "tags"=>VectorOf(AbstractString))
-        check_dataset_name(conf["name"])
-        new(UUID(conf["uuid"]), conf)
+    function DataSet(project, conf)
+        _validate_dataset_config(conf)
+        new(project, UUID(conf["uuid"]), conf)
     end
-
-    #=
-    name::String # Default name for convenience.
-                         # The binding to an actual name is managed by the data
-                         # project.
-    storage        # Storage config and driver definition
-    maps::Vector{DataMap}
-
-    # Generic dictionary of other properties... for now. Required properties
-    # will be moved
-    _other::Dict{Symbol,Any}
-
-    #storage_id     # unique identifier in storage backend, if it exists
-    #owner          # Project or user who owns the data
-    #description::String
-    #type           # Some representation of the type of data?
-    #               # An array, blob, table, tree, etc
-    #cachable::Bool # Can the data be cached?  It might not for data governance
-    #               # reasons or it might change commonly.
-    ## A set of identifiers
-    #tags::Set{String}
-    =#
 end
+
+DataSet(conf) = DataSet(nothing, conf)
 
 _key_match(config, (k,T)::Pair) = haskey(config, k) && config[k] isa T
 _key_match(config, k::String) = haskey(config, k)
@@ -77,6 +52,15 @@ function _check_optional_keys(config, context, keys...)
             end
         end
     end
+end
+
+function _validate_dataset_config(conf)
+    _check_keys(conf, DataSet, ["uuid"=>String, "storage"=>Dict, "name"=>String])
+    _check_keys(conf["storage"], DataSet, ["driver"=>String])
+    _check_optional_keys(conf,
+                         "description"=>AbstractString,
+                         "tags"=>VectorOf(AbstractString))
+    check_dataset_name(conf["name"])
 end
 
 """
@@ -158,6 +142,21 @@ function Base.show(io::IO, ::MIME"text/plain", d::DataSet)
     TOML.print(io, d.conf)
 end
 
+function config(dataset::DataSet; kws...)
+    config(dataset.project, dataset; kws...)
+end
+
+# The default case of a dataset config update when the update is independent of
+# the project.  (In general, projects may supply extra constraints.)
+function config(::Nothing, dataset::DataSet; kws...)
+    for (k,v) in pairs(kws)
+        if k in (:uuid, :name)
+            error("Cannot modify dataset config with key $k")
+        end
+        dataset.conf[string(k)] = v
+    end
+    return dataset
+end
 
 #-------------------------------------------------------------------------------
 # Functions for opening datasets

--- a/src/DataSet.jl
+++ b/src/DataSet.jl
@@ -85,10 +85,13 @@ function check_dataset_name(name::AbstractString)
     end
 end
 
-# Hacky thing until we figure out which fields DataSet should actually have.
+#-------------------------------------------------------------------------------
+# API for DataSet type
 function Base.getproperty(d::DataSet, name::Symbol)
-    if name in fieldnames(DataSet)
-        return getfield(d, name)
+    if name === :uuid
+        getfield(d, :uuid)
+    elseif name === :conf
+        getfield(d, :conf)
     else
         getfield(d, :conf)[string(name)]
     end
@@ -96,6 +99,10 @@ end
 
 Base.getindex(d::DataSet, name::AbstractString) = getindex(d.conf, name)
 Base.haskey(d::DataSet, name::AbstractString) = haskey(d.conf, name)
+
+function data_project(dataset::DataSet)
+    return getfield(dataset, :project)
+end
 
 # Split the fragment section as a '/' separated RelPath
 function dataspec_fragment_as_path(d::DataSet)
@@ -109,7 +116,7 @@ function dataspec_fragment_as_path(d::DataSet)
 end
 
 function config(dataset::DataSet; kws...)
-    config(dataset.project, dataset; kws...)
+    config(data_project(dataset), dataset; kws...)
 end
 
 # The default case of a dataset config update when the update is independent of

--- a/src/DataSet.jl
+++ b/src/DataSet.jl
@@ -115,16 +115,18 @@ function dataspec_fragment_as_path(d::DataSet)
     return nothing
 end
 
-function config(dataset::DataSet; kws...)
-    config(data_project(dataset), dataset; kws...)
+function config!(dataset::DataSet; kws...)
+    config!(data_project(dataset), dataset; kws...)
 end
 
 # The default case of a dataset config update when the update is independent of
 # the project.  (In general, projects may supply extra constraints.)
-function config(::Nothing, dataset::DataSet; kws...)
+function config!(::Nothing, dataset::DataSet; kws...)
     for (k,v) in pairs(kws)
         if k in (:uuid, :name)
             error("Cannot modify dataset config with key $k")
+        # TODO: elseif k === :storage
+            # Check consistency using storage driver API?
         end
         dataset.conf[string(k)] = v
     end

--- a/src/DataSet.jl
+++ b/src/DataSet.jl
@@ -97,6 +97,10 @@ function Base.getproperty(d::DataSet, name::Symbol)
     end
 end
 
+function Base.setproperty!(d::DataSet, name::Symbol, x)
+    config!(d; name=>x)
+end
+
 Base.getindex(d::DataSet, name::AbstractString) = getindex(d.conf, name)
 Base.haskey(d::DataSet, name::AbstractString) = haskey(d.conf, name)
 
@@ -127,6 +131,17 @@ function config!(::Nothing, dataset::DataSet; kws...)
             error("Cannot modify dataset config with key $k")
         # TODO: elseif k === :storage
             # Check consistency using storage driver API?
+        end
+        # TODO: Fold these schema checks in with _validate_dataset_config
+        # somehow.
+        if k === :description
+            if !(v isa AbstractString)
+                error("Dataset description must be a string")
+            end
+        elseif k === :tags
+            if !(v isa AbstractVector && all(x isa AbstractString for x in v))
+                error("Dataset tags must be a vector of strings")
+            end
         end
         dataset.conf[string(k)] = v
     end

--- a/src/DataSets.jl
+++ b/src/DataSets.jl
@@ -218,6 +218,8 @@ end
 
 
 #-------------------------------------------------------------------------------
+include("utils.jl")
+
 # Application entry points
 include("entrypoint.jl")
 

--- a/src/data_project.jl
+++ b/src/data_project.jl
@@ -70,15 +70,16 @@ use that name to search within the given data project.
 
 # Examples
 
-Update the dataset with name "SomeData" in the global project
+Update the description of the dataset named `"SomeData"` in the global project:
 ```
 DataSets.config!("SomeData"; description="This is a description")
 ```
 
-Tag the dataset "SomeData" with tags "A" and "B".
+Alternatively, setting `DataSet` properties can be used to update metadata. For
+example, to tag the dataset "SomeData" with tags `"A"` and `"B"`.
 ```
 ds = dataset("SomeData")
-DataSets.config!(ds, tags=["A", "B"])
+ds.tags = ["A", "B"]
 ```
 """
 function config!(project::AbstractDataProject, name::AbstractString; kws...)
@@ -351,18 +352,14 @@ function load_project(config::AbstractDict; kws...)
     proj
 end
 
-function save_project(path::AbstractString, proj::DataProject)
-    # TODO: Put this TOML conversion in DataProject ?
+function project_toml(proj::DataProject)
+    # FIXME: Preserve other unknown keys here for forward compatibility.
     conf = Dict(
         "data_config_version"=>CURRENT_DATA_CONFIG_VERSION,
         "datasets"=>[d.conf for (n,d) in proj.datasets],
         "drivers"=>proj.drivers
     )
-    mktemp(dirname(path)) do tmppath, tmpio
-        TOML.print(tmpio, conf)
-        close(tmpio)
-        mv(tmppath, path, force=true)
-    end
+    return sprint(TOML.print, conf)
 end
 
 function config!(name::AbstractString; kws...)

--- a/src/data_project.jl
+++ b/src/data_project.jl
@@ -53,16 +53,16 @@ function dataset(proj::AbstractDataProject, spec::AbstractString)
     conf["dataspec"] = dataspec
 
     # FIXME: This copy is problematic now that datasets can be mutated with
-    # `DataSets.config()` as "dataspec" will infect the dataset when it's
+    # `DataSets.config!()` as "dataspec" will infect the dataset when it's
     # saved again.
     return DataSet(data_project(dataset), conf)
 end
 
 """
-    config(name::AbstractString; kws...)
-    config(proj::AbstractDataProject, name::AbstractString; kws...)
+    config!(name::AbstractString; kws...)
+    config!(proj::AbstractDataProject, name::AbstractString; kws...)
 
-    config(dataset::DataSet; kws...)
+    config!(dataset::DataSet; kws...)
 
 Update the configuration of `dataset` with the given keyword arguments and
 persist it in the dataset's project storage. The versions which take a `name`
@@ -72,17 +72,17 @@ use that name to search within the given data project.
 
 Update the dataset with name "SomeData" in the global project
 ```
-DataSets.config("SomeData"; description="This is a description")
+DataSets.config!("SomeData"; description="This is a description")
 ```
 
 Tag the dataset "SomeData" with tags "A" and "B".
 ```
 ds = dataset("SomeData")
-config(ds, tags=["A", "B"])
+DataSets.config!(ds, tags=["A", "B"])
 ```
 """
-function config(project::AbstractDataProject, name::AbstractString; kws...)
-    config(project[name]; kws...)
+function config!(project::AbstractDataProject, name::AbstractString; kws...)
+    config!(project[name]; kws...)
 end
 
 # Percent-decode a string according to the URI escaping rules.
@@ -365,6 +365,6 @@ function save_project(path::AbstractString, proj::DataProject)
     end
 end
 
-function config(name::AbstractString; kws...)
-    config(PROJECT, name; kws...)
+function config!(name::AbstractString; kws...)
+    config!(PROJECT, name; kws...)
 end

--- a/src/file_data_projects.jl
+++ b/src/file_data_projects.jl
@@ -250,25 +250,20 @@ project_name(::ActiveDataProject) = _active_project_data_toml()
 
 #-------------------------------------------------------------------------------
 
-function _fill_template(toml_path, toml_str)
-    # Super hacky templating for paths relative to the toml file.
-    # We really should have something a lot nicer here...
-    if Sys.iswindows()
-        toml_path = replace(toml_path, '\\'=>'/')
-    end
+function _fill_template(toml_str)
     if occursin("@__DIR__", toml_str)
         Base.depwarn("""
             Using @__DIR__ in Data.toml is deprecated. Use a '/'-separated
             relative path instead.""",
             :_fill_template)
-        return replace(toml_str, "@__DIR__"=>toml_path)
+        return replace(toml_str, "@__DIR__"=>".")
     else
         return toml_str
     end
 end
 
 function _load_project(content::AbstractString, sys_data_dir)
-    toml_str = _fill_template(sys_data_dir, content)
+    toml_str = _fill_template(content)
     config = TOML.parse(toml_str)
     load_project(config)
 end

--- a/src/file_data_projects.jl
+++ b/src/file_data_projects.jl
@@ -127,13 +127,13 @@ Base.pairs(proj::AbstractTomlFileDataProject) = pairs(get_cache(proj))
 
 data_drivers(proj::AbstractTomlFileDataProject) = data_drivers(get_cache(proj))
 
-function config(proj::AbstractTomlFileDataProject, dataset::DataSet; kws...)
+function config!(proj::AbstractTomlFileDataProject, dataset::DataSet; kws...)
     if data_project(dataset) !== proj
         error("dataset must belong to project")
     end
     # Here we accept the update independently of the project - Data.toml should
     # be able to manage any dataset config.
-    config(nothing, dataset; kws...)
+    config!(nothing, dataset; kws...)
     save_project(proj.path, get_cache(proj, false))
     return dataset
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,38 @@
+# Some basic utilities to validate "config-like" data
+#
+# (Perhaps these could be replaced with the use of JSON schema or some such?)
+
+_key_match(config, (k,T)::Pair) = haskey(config, k) && config[k] isa T
+_key_match(config, k::String) = haskey(config, k)
+
+function _check_keys(config, context, keys)
+    missed_keys = filter(k->!_key_match(config, k), keys)
+    if !isempty(missed_keys)
+        error("""
+              Missing expected keys in $context:
+              $missed_keys
+
+              In DataSet fragment:
+              $(sprint(TOML.print,config))
+              """)
+    end
+end
+
+struct VectorOf
+    T
+end
+
+function _check_optional_keys(config, context, keys...)
+    for (k, check) in keys
+        if haskey(config, k)
+            v = config[k] 
+            if check isa Type && !(v isa check)
+                error("""Invalid DataSet key $k. Expected type $check""")
+            elseif check isa VectorOf && !(v isa AbstractVector &&
+                                           all(x isa check.T for x in v))
+                error("""Invalid DataSet key $k""")
+            end
+        end
+    end
+end
+

--- a/test/Data.toml
+++ b/test/Data.toml
@@ -12,16 +12,7 @@ uuid="b498f769-a7f6-4f67-8d74-40b770398f26"
     [datasets.storage]
     driver="FileSystem"
     type="File"
-    path="@__DIR__/data/file.txt"
-
-    # TODO: We'd like a layering abstraction.
-
-    # [[datasets.maps]]
-    # type="File"
-    #
-    # [[datasets.maps]]
-    # type="text"
-    # parameters={encoding="UTF-8"}
+    path="data/file.txt"
 
 [[datasets]]
 description="A text file with namespace"
@@ -31,7 +22,7 @@ uuid="b498f769-a7f6-4f67-8d74-40b770398f26"
     [datasets.storage]
     driver="FileSystem"
     type="File"
-    path="@__DIR__/data/file.txt"
+    path="data/file.txt"
 
 #--------------------------------------------------
 [[datasets]]
@@ -42,15 +33,7 @@ uuid="2d126588-5f76-4e53-8245-87dc91625bf4"
     [datasets.storage]
     driver="FileSystem"
     type="File"
-    path="@__DIR__/data/people.csv.gz"
-
-    #[[datasets.maps]]
-    #type="GZip"
-    #
-    #[[datasets.maps]]
-    #type="CSV"
-    #parameters={delim=","}
-
+    path="data/people.csv.gz"
 
 #--------------------------------------------------
 [[datasets]]
@@ -60,10 +43,7 @@ uuid="e7fd7080-e346-4a68-9ca9-98593a99266a"
     [datasets.storage]
     driver="FileSystem"
     type="FileTree"
-    path="@__DIR__/data/csvset"
-
-    # TODO: Add data maps here which expose it logically as a single CSV?
-
+    path="data/csvset"
 
 #--------------------------------------------------
 # Data embedded in the TOML

--- a/test/active_project/Data.toml
+++ b/test/active_project/Data.toml
@@ -8,4 +8,4 @@ uuid="314996ef-12be-40d0-912c-9755af354fdb"
     [datasets.storage]
     driver="FileSystem"
     type="File"
-    path="@__DIR__/data/file.txt"
+    path="data/file.txt"

--- a/test/active_project/Data.toml
+++ b/test/active_project/Data.toml
@@ -1,4 +1,4 @@
-data_config_version=0
+data_config_version=1
 
 [[datasets]]
 description="A text file"

--- a/test/backend_compat.jl
+++ b/test/backend_compat.jl
@@ -82,7 +82,7 @@ DataSets.add_storage_driver("OldBackendAPI"=>connect_old_backend)
     @test read(open(dataset(proj, "old_backend_tree"))[path"b.txt"], String) == "b"
 end
 
-@testset "Compat for renaming Blob->File, BlobTree->FileTree" begin
+@testset "Compat for @__DIR__ and renaming Blob->File, BlobTree->FileTree" begin
     proj = DataSets.load_project(joinpath(@__DIR__, "DataCompat.toml"))
 
     text_data = dataset(proj, "a_text_file")

--- a/test/projects.jl
+++ b/test/projects.jl
@@ -33,12 +33,6 @@ test_project_names = ["a_text_file",
 
     # identity
     @test project_name(proj) == abspath("Data.toml")
-
-    # Test @__DIR__ templating
-    # Use `cleanpath` as there's currently a mixture of / and \ on windows
-    # which does work, but is quite ugly.
-    cleanpath(p) = replace(p, '\\'=>'/')
-    @test cleanpath(proj["a_text_file"].storage["path"]) == cleanpath(joinpath(@__DIR__, "data", "file.txt"))
 end
 
 @testset "TomlFileDataProject live updates" begin
@@ -55,7 +49,7 @@ end
             [datasets.storage]
             driver="FileSystem"
             type="File"
-            path="@__DIR__/data/file.txt"
+            path="data/file.txt"
         """)
         flush(io)
 
@@ -74,7 +68,7 @@ end
             [datasets.storage]
             driver="FileSystem"
             type="File"
-            path="@__DIR__/data/file2.txt"
+            path="data/file2.txt"
         """)
         flush(io)
 

--- a/test/projects.jl
+++ b/test/projects.jl
@@ -39,7 +39,7 @@ end
     # Test live updating when the file is rewritten
     mktemp() do path,io
         write(io, """
-        data_config_version=0
+        data_config_version=1
 
         [[datasets]]
         description="A text file"

--- a/test/projects.jl
+++ b/test/projects.jl
@@ -6,7 +6,8 @@ using DataSets:
     TomlFileDataProject,
     ActiveDataProject,
     StackedDataProject,
-    project_name
+    project_name,
+    config!
 
 test_project_names = ["a_text_file",
                       "a_tree_example",
@@ -130,3 +131,63 @@ end
     @test project_name(DataSets.PROJECT.projects[1]) == joinpath(@__DIR__, "Data.toml")
 end
 
+@testset "config!() metadata update" begin
+    # Test live updating when the file is rewritten
+    mktempdir() do tmppath
+        data_toml_path = joinpath(tmppath, "Data.toml")
+        open(data_toml_path, write=true) do io
+            write(io, """
+            data_config_version=1
+
+            [[datasets]]
+            description="A"
+            name="a_text_file"
+            uuid="b498f769-a7f6-4f67-8d74-40b770398f26"
+
+                [datasets.storage]
+                driver="FileSystem"
+                type="File"
+                path="data/file.txt"
+            """)
+        end
+
+        proj = TomlFileDataProject(data_toml_path)
+        @testset "config!(proj, ...)" begin
+            @test dataset(proj, "a_text_file").description == "A"
+            config!(proj, "a_text_file", description="B")
+            config!(proj, "a_text_file", tags=Any["xx", "yy"])
+            @test dataset(proj, "a_text_file").description == "B"
+            @test dataset(proj, "a_text_file").tags == ["xx", "yy"]
+        end
+
+        @testset "Persistence on disk" begin
+            proj2 = TomlFileDataProject(data_toml_path)
+            @test dataset(proj2, "a_text_file").description == "B"
+            @test dataset(proj2, "a_text_file").tags == ["xx", "yy"]
+        end
+
+        @testset "config! via DataSet instances" begin
+            ds = dataset(proj, "a_text_file")
+            config!(ds, description = "C")
+            @test dataset(proj, "a_text_file").description == "C"
+            ds.description = "D"
+            @test dataset(proj, "a_text_file").description == "D"
+        end
+
+        @testset "description and tags validation" begin
+            ds = dataset(proj, "a_text_file")
+            @test_throws Exception config!(ds, description = 1)
+            @test_throws Exception config!(ds, tags = "hi")
+        end
+
+        @testset "global config! methods" begin
+            empty!(DataSets.PROJECT)
+            pushfirst!(DataSets.PROJECT, TomlFileDataProject(data_toml_path))
+
+            config!("a_text_file", description="X")
+            @test dataset("a_text_file").description == "X"
+
+            empty!(DataSets.PROJECT)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ end
 
 @testset "DataSet config from Dict" begin
     config = Dict(
-        "data_config_version"=>0,
+        "data_config_version"=>1,
         "datasets"=>[Dict(
             "description"=>"A text file",
             "name"=>"a_text_file",


### PR DESCRIPTION
This change allows dataset configuration to be modified via the `DataSets.config!()` API.

A notable internal change is that this requires each `DataSet` to be owned by one project, such that dataset changes can be written back to the project Data.toml (or other dataset project storage, such as JuliaHub).

Now that datasets can be mutated via the API, I found it necessary to remove and deprecate the crude `@__DIR__` templating mechanism for local file storage dataset paths, and simply specify that relative paths are relative to the location of the Data.toml, via the `local_data_abspath()` mechanism.

---

@jeremiedb, here's the user-facing documentation:

```
    config!(name::AbstractString; kws...)
    config!(proj::AbstractDataProject, name::AbstractString; kws...)

    config!(dataset::DataSet; kws...)
```

Update the configuration of `dataset` with the given keyword arguments and
persist it in the dataset's project storage. The versions which take a `name`
use that name to search within the given data project.

# Examples

Update the description of the dataset named `"SomeData"` in the global project:
```
DataSets.config!("SomeData"; description="This is a description")
```

Alternatively, setting `DataSet` properties can be used to update metadata. For
example, to tag the dataset "SomeData" with tags `"A"` and `"B"`.
```
ds = dataset("SomeData")
ds.tags = ["A", "B"]
```
