### PR TITLE
Backport allowing `-` in dataset names to 0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     strategy:
       matrix:
         version:
+          - '1.5'
+          - '1.7'
           - '1'
           - 'nightly'
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - release-*
     tags: '*'
   pull_request:
 jobs:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataSets"
 uuid = "c9661210-8a83-48f0-b833-72e62abce419"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/DataSets.jl
+++ b/src/DataSets.jl
@@ -91,7 +91,7 @@ separated with forward slashes. Examples:
     my_data
     my_data_1
     username/data
-    organization/project/data
+    organization-dataset_name/project/data
 """
 function check_dataset_name(name::AbstractString)
     # DataSet names disallow most punctuation for now, as it may be needed as
@@ -100,13 +100,13 @@ function check_dataset_name(name::AbstractString)
         ^
         [[:alpha:]]
         (?:
-            [[:alnum:]_]      |
+            [-[:alnum:]_]     |
             / (?=[[:alpha:]])
         )*
         $
         "x
     if !occursin(dataset_name_pattern, name)
-        error("DataSet name \"$name\" is invalid. DataSet names must start with a letter and can contain only letters, numbers, `_` or `/`.")
+        error("DataSet name \"$name\" is invalid. DataSet names must start with a letter and can contain only letters, numbers, `-`, `_` or `/`.")
     end
 end
 

--- a/test/driver_autoload.jl
+++ b/test/driver_autoload.jl
@@ -1,6 +1,6 @@
 @testset "Automatic code loading for drivers" begin
     empty!(DataSets.PROJECT)
-    pushfirst!(LOAD_PATH, abspath("drivers"))
+    Pkg.develop(path=joinpath(@__DIR__, "drivers", "DummyStorageBackends"))
     ENV["JULIA_DATASETS_PATH"] = joinpath(@__DIR__, "DriverAutoloadData.toml")
     DataSets.__init__()
     @test haskey(DataSets._storage_drivers, "DummyTomlStorage")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,8 +98,9 @@ end
     @test DataSets.check_dataset_name("δεδομένα") === nothing
     @test DataSets.check_dataset_name("a/b") === nothing
     @test DataSets.check_dataset_name("a/b/c") === nothing
+    @test DataSets.check_dataset_name("a-b-c-") === nothing
     # Invalid names
-    @test_throws ErrorException("DataSet name \"a?b\" is invalid. DataSet names must start with a letter and can contain only letters, numbers, `_` or `/`.") DataSets.check_dataset_name("a?b")
+    @test_throws ErrorException("DataSet name \"a?b\" is invalid. DataSet names must start with a letter and can contain only letters, numbers, `-`, `_` or `/`.") DataSets.check_dataset_name("a?b")
     @test_throws ErrorException DataSets.check_dataset_name("1")
     @test_throws ErrorException DataSets.check_dataset_name("a b")
     @test_throws ErrorException DataSets.check_dataset_name("a.b")


### PR DESCRIPTION
This backports a part of #40 that enables hyphens in dataset names to the 0.2 branch, for tagging as 0.2.7.

I created a new `release-0.2` tag for to track for the 0.2 branch of the code. I think ideally that should also be added a protected branch.

Also, there is precedent in expanding allowed dataset names in minor versions, with the `/` introduced in 0.2.4: https://github.com/JuliaComputing/DataSets.jl/commit/0a95d2137b62075e1ac82321fbc514c03e90643c