### PR TITLE
Fix nightly tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     strategy:
       matrix:
         version:
+          - '1.5'
+          - '1.7'
           - '1'
           - 'nightly'
         os:

--- a/test/driver_autoload.jl
+++ b/test/driver_autoload.jl
@@ -1,6 +1,6 @@
 @testset "Automatic code loading for drivers" begin
     empty!(DataSets.PROJECT)
-    pushfirst!(LOAD_PATH, abspath("drivers"))
+    Pkg.develop(path=joinpath(@__DIR__, "drivers", "DummyStorageBackends"))
     ENV["JULIA_DATASETS_PATH"] = joinpath(@__DIR__, "DriverAutoloadData.toml")
     DataSets.__init__()
     @test haskey(DataSets._storage_drivers, "DummyTomlStorage")


### PR DESCRIPTION
So I don't quite understand what has changed and why pushing to `LOAD_PATH` doesn't work any more on nightly, but using `Pkg.develop` seems fix it.

The issue seems to be that when you try to load `DummyStorageBackends` via `LOAD_PATH`, it looks for its DataSets dependency in the depo, rather than realizing that it's already loaded into `Main`. To repro locally, it may be necessary to have a clean depot.