### PR TITLE
Determine data repo from DEPOT_PATH

### DIFF
--- a/src/DataSets.jl
+++ b/src/DataSets.jl
@@ -146,7 +146,7 @@ interpreted as follows:
 This simplified version of the code loading rules (`LOAD_PATH`/`DEPOT_PATH``) is
 used as it seems unlikely that we'll want data location to be version-
 dependent in the same way that that code is. Note that any changes to `DEPOT_PATH`
-after `DataSets. has been loaded do not affect `DataSets.PROJECT`.
+after `DataSets` has been loaded do not affect `DataSets.PROJECT`.
 
 Unlike `LOAD_PATH`, `JULIA_DATASETS_PATH` is represented inside the program as
 a `StackedDataProject`, and users can add custom projects by defining their own

--- a/src/DataSets.jl
+++ b/src/DataSets.jl
@@ -86,7 +86,7 @@ function data_project_from_path(path; depot_paths)
         #
         # To offer a little bit more reliability here for the user, we absolutize the
         # path when DataSets gets loaded, so that things would not be affected by the
-        # user changing directories, but we also
+        # user changing directories.
         if !isabspath(depot)
             depot = abspath(expanduser(depot))
             @warn "Julia depot path ($(first(depot_paths))) not absolute. Fixing data project path relative to current working directory." depot

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -212,7 +212,7 @@ function parse_data_repl_cmd(cmdstr)
         if subcmd == "push"
             path = popfirst!(tokens)
             return quote
-                proj = $DataSets.data_project_from_path($path)
+                proj = $DataSets.data_project_from_path($path; depot_paths=DEPOT_PATH)
                 stack = $DataSets.PROJECT
                 pushfirst!(stack, proj)
                 stack


### PR DESCRIPTION
Currently, if you pass an empty `JULIA_DATASETS_PATH` element, we default to `joinpath(homedir(), ".julia", "datasets", "Data.toml")`. But we probably want to make sure we use the actual depot, if the user has set their own `JULIA_DEPOT_PATH`.