### PR TITLE
Handle hyphens in dataset()

### DIFF
--- a/src/DataSet.jl
+++ b/src/DataSet.jl
@@ -51,20 +51,17 @@ separated with forward slashes. Examples:
     username/data
     organization/project/data
 """
-function is_valid_dataset_name(name::AbstractString)
-    # DataSet names disallow most punctuation for now, as it may be needed as
-    # delimiters in data-related syntax (eg, for the data REPL).
-    dataset_name_pattern = r"
-        ^
-        [[:alpha:]]
-        (?:
-            [-[:alnum:]_]     |
-            / (?=[[:alpha:]])
-        )*
-        $
-        "x
-    return occursin(dataset_name_pattern, name)
-end
+is_valid_dataset_name(name::AbstractString) = occursin(DATASET_NAME_REGEX, name)
+# DataSet names disallow most punctuation for now, as it may be needed as
+# delimiters in data-related syntax (eg, for the data REPL).
+const DATASET_NAME_REGEX_STRING = raw"""
+[[:alpha:]]
+(?:
+    [-[:alnum:]_]     |
+    / (?=[[:alpha:]])
+)*
+"""
+const DATASET_NAME_REGEX = Regex("^\n$(DATASET_NAME_REGEX_STRING)\n\$", "x")
 
 function make_valid_dataset_name(name)
     if !is_valid_dataset_name(name)
@@ -191,4 +188,3 @@ function Base.open(as_type, dataset::DataSet)
         @! ResourceContexts.detach_context_cleanup(result)
     end
 end
-

--- a/src/data_project.jl
+++ b/src/data_project.jl
@@ -107,16 +107,20 @@ function _unescapeuri(str)
     return String(take!(out))
 end
 
+# Parse as a suffix of URI syntax
+# name/of/dataset?param1=value1&param2=value2#fragment
+const DATASET_SPEC_REGEX = Regex(
+    """
+    ^
+    ($(DATASET_NAME_REGEX_STRING))
+    (?:\\?([^#]*))? # query    - a=b&c=d
+    (?:\\#(.*))?    # fragment - ...
+    \$
+    """,
+    "x",
+)
 function _split_dataspec(spec::AbstractString)
-    # Parse as a suffix of URI syntax
-    # name/of/dataset?param1=value1&param2=value2#fragment
-    m = match(r"
-        ^
-        ((?:[[:alpha:]][[:alnum:]_]*/?)+)  # name     - a/b/c
-        (?:\?([^#]*))?                     # query    - a=b&c=d
-        (?:\#(.*))?                        # fragment - ...
-        $"x,
-        spec)
+    m = match(DATASET_SPEC_REGEX, spec)
     if isnothing(m)
         return nothing, nothing, nothing
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,20 +78,16 @@ end
 
 #-------------------------------------------------------------------------------
 @testset "Data set names" begin
-    # Valid names
-    @test DataSets.is_valid_dataset_name("a_b")
-    @test DataSets.is_valid_dataset_name("a-b")
-    @test DataSets.is_valid_dataset_name("a1")
-    @test DataSets.is_valid_dataset_name("δεδομένα")
-    @test DataSets.is_valid_dataset_name("a/b")
-    @test DataSets.is_valid_dataset_name("a/b/c")
-    # Invalid names
-    @test !DataSets.is_valid_dataset_name("1")
-    @test !DataSets.is_valid_dataset_name("a b")
-    @test !DataSets.is_valid_dataset_name("a.b")
-    @test !DataSets.is_valid_dataset_name("a/b/")
-    @test !DataSets.is_valid_dataset_name("a//b")
-    @test !DataSets.is_valid_dataset_name("/a/b")
+    @testset "Valid name: $name" for name in ("a_b", "a-b", "a1", "δεδομένα", "a/b", "a/b/c")
+        @test DataSets.is_valid_dataset_name(name)
+        @test DataSets._split_dataspec(name) == (name, nothing, nothing)
+    end
+
+    @testset "Invalid name: $name" for name in ("1", "a b", "a.b", "a/b/", "a//b", "/a/b")
+        @test !DataSets.is_valid_dataset_name(name)
+        @test DataSets._split_dataspec(name) == (nothing, nothing, nothing)
+    end
+
     # Error message for invalid names
     @test_throws ErrorException("DataSet name \"a?b\" is invalid. DataSet names must start with a letter and can contain only letters, numbers, `_` or `/`.") DataSets.check_dataset_name("a?b")
 


### PR DESCRIPTION
When calling `dataset("dataset-name")`, it actually has its own regex it checks when it parses it (because of query parameters), and it doesn't currently handle hyphens.

I now try to reuse the regex string for the dataset name, rather than having two separate regexes that do partially the same thing.

It should also be backported to 0.2.

---

This is how the new regexes print:

```
julia> DataSets.DATASET_NAME_REGEX
r"^
[[:alpha:]]
(?:
    [-[:alnum:]_]     |
    / (?=[[:alpha:]])
)*

$"x

julia> DataSets.DATASET_SPEC_REGEX
r"^
([[:alpha:]]
(?:
    [-[:alnum:]_]     |
    / (?=[[:alpha:]])
)*
)
(?:\?([^#]*))? # query    - a=b&c=d
(?:\#(.*))?    # fragment - ...
$
"x
```