### PR TITLE
fix: allow AbstractTrees 0.4 on release-0.2 branch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataSets"
 uuid = "c9661210-8a83-48f0-b833-72e62abce419"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -15,7 +15,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-AbstractTrees = "0.3"
+AbstractTrees = "0.3,0.4"
 ReplMaker = "0.2"
 ResourceContexts = "0.1,0.2"
 TOML = "1"


### PR DESCRIPTION
Also bump the DataSets.jl version to 0.2.9 for release.

#47 was never tagged because master and release-0.2 have diverged.