### PR TITLE
[release-0.2] feat: add way to register post-__init__ callbacks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataSets"
 uuid = "c9661210-8a83-48f0-b833-72e62abce419"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,14 @@ using ResourceContexts
 
 using DataSets: FileSystemRoot
 
-#-------------------------------------------------------------------------------
+@testset "register_post_init_callback" begin
+    init_was_called = Ref(false)
+    DataSets.register_post_init_callback() do
+        init_was_called[] = true
+    end
+    @test init_was_called[]
+end
+
 @testset "DataSet config" begin
     proj = DataSets.load_project("Data.toml")
 


### PR DESCRIPTION
Adds a `register_post_init_callback` function that can be used to register callbacks that are guaranteed to be called after `DataSets.__init__()` has run (critically, including in sysimages). Unfortunately, I can't really think of a easy way to test the queueing, since even in a sysimage, but it seems to work correctly.

This PR is directly against `release-0.2` and bumps the version as well. Will forward-port this to master in a separate PR.