### PR TITLE
fix: ensure TOML serialization in `show()` does not break it

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataSets"
 uuid = "c9661210-8a83-48f0-b833-72e62abce419"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.2.12"
+version = "0.2.13"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/DataSets.jl
+++ b/src/DataSets.jl
@@ -172,7 +172,7 @@ function Base.show(io::IO, ::MIME"text/plain", d::DataSet)
         end
     catch e
         @debug "Failed to serialize DataSet to TOML" exception = (e, catch_backtrace())
-        print(io, "\n<unserializable>")
+        print(io, "\n... <unserializable>")
     end
 end
 

--- a/src/DataSets.jl
+++ b/src/DataSets.jl
@@ -166,8 +166,13 @@ function Base.show(io::IO, ::MIME"text/plain", d::DataSet)
     # underlying dictionary as TOML. However, not all Julia values can be
     # serialized, so we do a best-effort sanitization of the dictionary to
     # ensure it is serializable.
-    TOML.print(io, d.conf) do _
-        "<unserializable>"
+    try
+        TOML.print(io, d.conf) do _
+            "<unserializable>"
+        end
+    catch e
+        @debug "Failed to serialize DataSet to TOML" exception = (e, catch_backtrace())
+        print(io, "\n<unserializable>")
     end
 end
 

--- a/src/DataSets.jl
+++ b/src/DataSets.jl
@@ -173,6 +173,7 @@ function Base.show(io::IO, ::MIME"text/plain", d::DataSet)
     catch e
         @debug "Failed to serialize DataSet to TOML" exception = (e, catch_backtrace())
         print(io, "\n... <unserializable>")
+        print(io, "\nSet JULIA_DEBUG=DataSets to see the error")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,9 @@ end
         @test parsed isa Dict
         @test parsed["name"] == "a_text_file"
         @test parsed["uuid"] == "b498f769-a7f6-4f67-8d74-40b770398f26"
+        @test parsed["foo"] == "<unserializable>"
+        @test parsed["bar"] == [1, 2, "<unserializable>", Dict("x" => "<unserializable>", "y" => "y")]
+        @test parsed["baz"] == Dict("x" => "<unserializable>", "y" => "y")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,24 @@ end
         @test parsed["bar"] == [1, 2, "<unserializable>", Dict("x" => "<unserializable>", "y" => "y")]
         @test parsed["baz"] == Dict("x" => "<unserializable>", "y" => "y")
     end
+
+    # Also test bad keys
+    config["datasets"][1]["keys"] = Dict(
+        nothing => 123,
+        1234 => "bad",
+    )
+    proj = DataSets.load_project(config)
+    ds = dataset(proj, "a_text_file")
+    let s = sprint(show, "text/plain", ds)
+        endswith(s, "\n... <unserializable>")
+        parsed = TOML.parse(s)
+        @test parsed isa Dict
+        @test parsed["name"] == "a_text_file"
+        @test parsed["uuid"] == "b498f769-a7f6-4f67-8d74-40b770398f26"
+        @test parsed["foo"] == "<unserializable>"
+        @test parsed["bar"] == [1, 2, "<unserializable>", Dict("x" => "<unserializable>", "y" => "y")]
+        @test parsed["baz"] == Dict("x" => "<unserializable>", "y" => "y")
+    end
 end
 
 @testset "open() for DataSet" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,13 +87,6 @@ end
     ds = dataset(proj, "a_text_file")
     let s = sprint(show, "text/plain", ds)
         endswith(s, "\n... <unserializable>")
-        parsed = TOML.parse(s)
-        @test parsed isa Dict
-        @test parsed["name"] == "a_text_file"
-        @test parsed["uuid"] == "b498f769-a7f6-4f67-8d74-40b770398f26"
-        @test parsed["foo"] == "<unserializable>"
-        @test parsed["bar"] == [1, 2, "<unserializable>", Dict("x" => "<unserializable>", "y" => "y")]
-        @test parsed["baz"] == Dict("x" => "<unserializable>", "y" => "y")
     end
 end
 


### PR DESCRIPTION
If we happen to get `nothing`s or other values that TOML.jl can not serialize in the the `DataSet`'s `.conf`, the `show()` method will break printing in the REPL. So let's get rid of all problematic values. We don't care here that it is round-trippable -- this is just for a pretty `show` method.

In addition, there `TOML.print`'s `to_toml` does not handle e.g. unsupported `Dict` _keys_. So we also just put a catchall try-catch around it and print something sensible, so that the users wouldn't be presented with a big `show` method stacktrace.